### PR TITLE
Fedora 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:28
 
 ENV VERSION 3.9
 


### PR DESCRIPTION
Converted fedora to fedora 28, the currently supported version